### PR TITLE
Implement pricing calculation for operator fees based on staff type and equipment complexity

### DIFF
--- a/app/Http/Controllers/Admin/OperatorRateController.php
+++ b/app/Http/Controllers/Admin/OperatorRateController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use App\Models\Equipment;
+
+class OperatorRateController extends Controller
+{
+    /** Pokaż listę unikalnych kategorii ze stawkami */
+    public function index()
+    {
+        // pobieramy każdą kategorię i jej (identyczną) stawkę
+        $rates = Equipment::query()
+            ->select('category', DB::raw('MAX(operator_rate) as operator_rate'))
+            ->groupBy('category')
+            ->orderBy('category')
+            ->get();
+
+        return view('admin.operator_rates.index', compact('rates'));
+    }
+
+    /** Formularz edycji dla jednej kategorii */
+    public function edit($category)
+    {
+        // zabezpiecz nazwę kategorii (URL encoded)
+        $decoded = urldecode($category);
+
+        // wybieramy aktualną stawkę (może być null albo 0)
+        $current = Equipment::where('category', $decoded)
+            ->value('operator_rate');
+
+        return view('admin.operator_rates.edit', [
+            'category'         => $decoded,
+            'current_operator_rate' => $current,
+        ]);
+    }
+
+    /** Zapisujemy nową stawkę – masowo dla wszystkich sprzętów z tą kategorią */
+    public function update(Request $request, $category)
+    {
+        $decoded = urldecode($category);
+
+        $data = $request->validate([
+            'operator_rate' => ['required','numeric','min:0'],
+        ]);
+
+        Equipment::where('category', $decoded)
+            ->update(['operator_rate' => $data['operator_rate']]);
+
+        return redirect()->route('admin.operator-rates.index')
+            ->with('success', "Stawkę dla kategorii “{$decoded}” ustawiono na {$data['operator_rate']} zł/dzień.");
+    }
+}

--- a/app/Models/Equipment.php
+++ b/app/Models/Equipment.php
@@ -25,6 +25,7 @@ class Equipment extends Model
         'discount',
         'start_datetime',
         'end_datetime',
+        'operator_rate',
         'number_of_rentals',
     ];
 
@@ -110,5 +111,18 @@ class Equipment extends Model
         // Dla innych przypadków zwróć false
         return false;
     }
+
+    protected $casts = [
+        'rental_price'    => 'decimal:2',
+        'operator_rate'   => 'decimal:2',
+        'number_of_rentals' => 'integer',
+    ];
+
+    public function getOperatorDailyRateAttribute(): float
+    {
+        // po prostu zwraca wartość z kolumny
+        return $this->operator_rate;
+    }
+
 }
 

--- a/database/migrations/2025_05_30_161349_add_costs_and_operator_to_rentals_table.php
+++ b/database/migrations/2025_05_30_161349_add_costs_and_operator_to_rentals_table.php
@@ -1,0 +1,69 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddCostsAndOperatorToRentalsTable extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('rentals', function (Blueprint $table) {
+            if (! Schema::hasColumn('rentals', 'with_operator')) {
+                $table->boolean('with_operator')->default(false)->after('end_date');
+            }
+
+            if (! Schema::hasColumn('rentals', 'days')) {
+                $table->integer('days')->unsigned()->nullable()->after('with_operator');
+            }
+
+            if (! Schema::hasColumn('rentals', 'equipment_daily_rate')) {
+                $table->decimal('equipment_daily_rate', 8, 2)
+                    ->nullable()
+                    ->after('days');
+            }
+
+            if (! Schema::hasColumn('rentals', 'equipment_cost')) {
+                $table->decimal('equipment_cost', 10, 2)
+                    ->nullable()
+                    ->after('equipment_daily_rate');
+            }
+
+            if (! Schema::hasColumn('rentals', 'operator_daily_rate')) {
+                $table->decimal('operator_daily_rate', 8, 2)
+                    ->nullable()
+                    ->after('equipment_cost');
+            }
+
+            if (! Schema::hasColumn('rentals', 'operator_cost')) {
+                $table->decimal('operator_cost', 10, 2)
+                    ->nullable()
+                    ->after('operator_daily_rate');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('rentals', function (Blueprint $table) {
+            if (Schema::hasColumn('rentals', 'operator_cost')) {
+                $table->dropColumn('operator_cost');
+            }
+            if (Schema::hasColumn('rentals', 'operator_daily_rate')) {
+                $table->dropColumn('operator_daily_rate');
+            }
+            if (Schema::hasColumn('rentals', 'equipment_cost')) {
+                $table->dropColumn('equipment_cost');
+            }
+            if (Schema::hasColumn('rentals', 'equipment_daily_rate')) {
+                $table->dropColumn('equipment_daily_rate');
+            }
+            if (Schema::hasColumn('rentals', 'days')) {
+                $table->dropColumn('days');
+            }
+            if (Schema::hasColumn('rentals', 'with_operator')) {
+                $table->dropColumn('with_operator');
+            }
+        });
+    }
+}

--- a/database/migrations/2025_05_30_161541_add_operator_rate_to_equipment_table.php
+++ b/database/migrations/2025_05_30_161541_add_operator_rate_to_equipment_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddOperatorRateToEquipmentTable extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('equipment', function (Blueprint $table) {
+            // stawka operatora za dzień, zależna od kategorii sprzętu
+            $table->decimal('operator_rate', 8, 2)
+                ->default(0)
+                ->after('category');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('equipment', function (Blueprint $table) {
+            $table->dropColumn('operator_rate');
+        });
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -19,6 +19,7 @@ class DatabaseSeeder extends Seeder
             RentalSeeder::class,
             PaymentSeeder::class,
             RentalJanSeeder::class,
+            EquipmentOperatorRateSeeder::class
         ]);
     }
 

--- a/database/seeders/EquipmentOperatorRateSeeder.php
+++ b/database/seeders/EquipmentOperatorRateSeeder.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class EquipmentOperatorRateSeeder extends Seeder
+{
+    public function run(): void
+    {
+        // 1. Pobieramy unikalne kategorie z bazy
+        $categories = DB::table('equipment')
+            ->select('category')
+            ->distinct()
+            ->pluck('category');
+
+        $this->command->info('Znalezione kategorie:');
+        foreach ($categories as $cat) {
+            $this->command->line("  – “{$cat}”");
+        }
+
+        // 2. Mapa stawek
+        $rates = [
+            'Młoty wyburzeniowe / udarowe' => 500,
+            'Pilarki i piły mechaniczne'   => 200,
+            'Minikoparki'                  => 650,
+            'Podnośniki i zwyżki'          => 450,
+            'Zagęszczarki i ubijaki'       => 300,
+            'Betoniarki'                   => 250,
+            'Wiertarki i wkrętarki'        => 180,
+            'Ładowarki'                    => 550,
+            'Osuszacze i nagrzewnice'      => 150,
+            'Sprężarki i kompresory'       => 400,
+            'Agregaty prądotwórcze'        => 350,
+            'Rusztowania i drabiny'        => 220,
+            'Koparki'                      => 700,
+            'Pompy wodne'                  => 280,
+            'Szlifierki i przecinarki'     => 260,
+            'Lasery budowlane i niwelatory'=> 300,
+        ];
+
+        // 3. Aktualizacja i logowanie
+        foreach ($categories as $category) {
+            $rate = $rates[$category] ?? null;
+            if ($rate === null) {
+                $this->command->warn("Brak stawki dla kategorii “{$category}” – zostawiamy 0");
+                continue;
+            }
+            DB::table('equipment')
+                ->where('category', $category)
+                ->update(['operator_rate' => $rate]);
+
+            $this->command->info("Ustawiono operator_rate={$rate} dla kategorii “{$category}”");
+        }
+    }
+}

--- a/resources/views/admin/equipment/create.blade.php
+++ b/resources/views/admin/equipment/create.blade.php
@@ -14,24 +14,36 @@
             </div>
         @endif
 
+        {{-- Przygotuj mapę kategorii → stawek --}}
+        @php
+            use Illuminate\Support\Facades\DB;
+            $categoryRates = DB::table('equipment')
+                ->select('category', DB::raw('MAX(operator_rate) as rate'))
+                ->groupBy('category')
+                ->pluck('rate', 'category');
+        @endphp
+
         <form action="{{ route('admin.equipment.store') }}" method="POST" enctype="multipart/form-data" class="space-y-5">
             @csrf
 
+            {{-- Nazwa --}}
             <div>
                 <label for="name" class="block font-medium mb-1">Nazwa</label>
-                <input type="text" name="name" required value="{{ old('name') }}"
+                <input type="text" name="name" id="name" required value="{{ old('name') }}"
                        class="w-full rounded-lg border-gray-300 shadow-sm focus:border-[#f56600] focus:ring-[#f56600] px-4 py-2">
             </div>
 
+            {{-- Opis --}}
             <div>
                 <label for="description" class="block font-medium mb-1">Opis</label>
-                <textarea name="description" rows="4" required
+                <textarea name="description" id="description" rows="4" required
                           class="w-full rounded-lg border-gray-300 shadow-sm focus:border-[#f56600] focus:ring-[#f56600] px-4 py-2">{{ old('description') }}</textarea>
             </div>
 
+            {{-- Dostępność --}}
             <div>
                 <label for="availability" class="block font-medium mb-1">Dostępność</label>
-                <select name="availability" required
+                <select name="availability" id="availability" required
                         class="w-full rounded-lg border-gray-300 shadow-sm focus:border-[#f56600] focus:ring-[#f56600] px-4 py-2">
                     <option value="">-- Wybierz --</option>
                     <option value="dostepny" {{ old('availability') == 'dostepny' ? 'selected' : '' }}>Dostępny</option>
@@ -40,27 +52,32 @@
                 </select>
             </div>
 
+            {{-- Cena wynajmu --}}
             <div>
                 <label for="rental_price" class="block font-medium mb-1">Cena wynajmu (zł)</label>
-                <input type="number" name="rental_price" step="0.01" required value="{{ old('rental_price') }}"
+                <input type="number" name="rental_price" id="rental_price" step="0.01" required
+                       value="{{ old('rental_price') }}"
                        class="w-full rounded-lg border-gray-300 shadow-sm focus:border-[#f56600] focus:ring-[#f56600] px-4 py-2">
             </div>
 
+            {{-- Miniatura --}}
             <div>
                 <label for="thumbnail" class="block font-medium mb-1">Miniatura (1 plik)</label>
-                <input type="file" name="thumbnail" accept="image/*" required
+                <input type="file" name="thumbnail" id="thumbnail" accept="image/*" required
                        class="w-full rounded-lg border-gray-300 px-3 py-2 file:mr-4 file:rounded file:border-0 file:bg-[#f56600] file:px-4 file:py-2 file:text-white">
             </div>
 
+            {{-- Dodatkowe zdjęcia --}}
             <div>
                 <label for="photos[]" class="block font-medium mb-1">Zdjęcia dodatkowe (można wiele)</label>
-                <input type="file" name="photos[]" multiple accept="image/*"
+                <input type="file" name="photos[]" id="photos[]" multiple accept="image/*"
                        class="w-full rounded-lg border-gray-300 px-3 py-2 file:mr-4 file:rounded file:border-0 file:bg-[#f56600] file:px-4 file:py-2 file:text-white">
             </div>
 
+            {{-- Stan techniczny --}}
             <div>
                 <label for="technical_state" class="block font-medium mb-1">Stan techniczny</label>
-                <select name="technical_state" required
+                <select name="technical_state" id="technical_state" required
                         class="w-full rounded-lg border-gray-300 shadow-sm focus:border-[#f56600] focus:ring-[#f56600] px-4 py-2">
                     <option value="">-- Wybierz --</option>
                     <option value="nowy" {{ old('technical_state') == 'nowy' ? 'selected' : '' }}>Nowy</option>
@@ -69,6 +86,7 @@
                 </select>
             </div>
 
+            {{-- Kategoria + stawka operatora --}}
             <div>
                 <label class="block font-medium mb-1">Kategoria</label>
 
@@ -80,7 +98,7 @@
                 <select id="existing-category"
                         class="w-full hidden rounded-lg border-gray-300 shadow-sm focus:border-[#f56600] focus:ring-[#f56600] px-4 py-2 mb-2">
                     <option value="">-- Wybierz istniejącą kategorię --</option>
-                    @foreach(\App\Models\Equipment::select('category')->distinct()->pluck('category') as $cat)
+                    @foreach($categoryRates->keys() as $cat)
                         <option value="{{ $cat }}">{{ $cat }}</option>
                     @endforeach
                 </select>
@@ -91,9 +109,26 @@
                        class="w-full rounded-lg border-gray-300 shadow-sm focus:border-[#f56600] focus:ring-[#f56600] px-4 py-2">
             </div>
 
+            {{-- Pole stawki operatora --}}
+            <div id="operator-rate-group">
+                <label for="operator_rate" class="block font-medium mb-1">Stawka operatora (zł/dzień)</label>
+                <input type="number"
+                       name="operator_rate"
+                       id="operator_rate"
+                       step="0.01"
+                       min="0"
+                       value="{{ old('operator_rate') }}"
+                       required
+                       class="w-full rounded-lg border-gray-300 shadow-sm focus:border-[#f56600] focus:ring-[#f56600] px-4 py-2 @error('operator_rate') border-red-500 @enderror">
+                @error('operator_rate')
+                <p class="text-red-600 text-sm mt-1">{{ $message }}</p>
+                @enderror
+            </div>
+
+            {{-- Submit --}}
             <div class="flex items-center gap-4 pt-4">
                 <button type="submit"
-                        class="inline-flex items-center rounded-lg bg-[#f56600]  px-5 py-2 text-white hover:bg-[#ff6900] ">
+                        class="inline-flex items-center rounded-lg bg-[#f56600] px-5 py-2 text-white hover:bg-[#ff6900]">
                     Dodaj sprzęt
                 </button>
                 <a href="{{ route('admin.equipment.index') }}"
@@ -108,9 +143,13 @@
 @push('scripts')
     <script>
         document.addEventListener('DOMContentLoaded', function () {
-            const toggleBtn = document.getElementById('toggle-category-mode');
+            // Mapa kategorii → stawek
+            const categoryRates = @json($categoryRates);
+
+            const toggleBtn      = document.getElementById('toggle-category-mode');
             const selectCategory = document.getElementById('existing-category');
-            const inputCategory = document.getElementById('category');
+            const inputCategory  = document.getElementById('category');
+            const rateInput      = document.getElementById('operator_rate');
 
             let usingSelect = false;
 
@@ -121,18 +160,43 @@
                     inputCategory.classList.add('hidden');
                     selectCategory.classList.remove('hidden');
                     inputCategory.value = '';
+                    rateInput.value     = '';
+                    rateInput.readOnly  = true;
                     toggleBtn.textContent = 'Wpisz kategorię';
                 } else {
                     selectCategory.classList.add('hidden');
                     inputCategory.classList.remove('hidden');
                     selectCategory.value = '';
+                    rateInput.value     = '';
+                    rateInput.readOnly  = false;
                     toggleBtn.textContent = 'Wybierz z listy';
                 }
             });
 
             selectCategory.addEventListener('change', function () {
-                inputCategory.value = this.value;
+                const cat = this.value;
+                inputCategory.value = cat;
+                const rate = categoryRates[cat] ?? '';
+                rateInput.value     = rate;
+                rateInput.readOnly  = true;
+            });
+
+            // ————— DODATKOWA WALIDACJA FRONT-END —————
+            // Jeżeli wpiszesz ręcznie w pole kategorii nazwę istniejącą w mapie,
+            // to automatycznie zablokujemy edycję stawki na tę istniejącą wartość.
+            inputCategory.addEventListener('blur', function () {
+                const cat = this.value.trim();
+                if (!usingSelect && cat && categoryRates.hasOwnProperty(cat)) {
+                    // Kategoria istnieje — pobierz stawkę i zablokuj pole
+                    rateInput.value    = categoryRates[cat];
+                    rateInput.readOnly = true;
+                } else if (!usingSelect) {
+                    // Nowa kategoria — pozwól edytować stawkę
+                    rateInput.value    = '';
+                    rateInput.readOnly = false;
+                }
             });
         });
     </script>
+
 @endpush

--- a/resources/views/admin/equipment/create.blade.php
+++ b/resources/views/admin/equipment/create.blade.php
@@ -143,9 +143,7 @@
 @push('scripts')
     <script>
         document.addEventListener('DOMContentLoaded', function () {
-            // Mapa kategorii → stawek
             const categoryRates = @json($categoryRates);
-
             const toggleBtn      = document.getElementById('toggle-category-mode');
             const selectCategory = document.getElementById('existing-category');
             const inputCategory  = document.getElementById('category');
@@ -153,47 +151,48 @@
 
             let usingSelect = false;
 
-            toggleBtn.addEventListener('click', function () {
+            toggleBtn.addEventListener('click', () => {
                 usingSelect = !usingSelect;
 
                 if (usingSelect) {
+                    // Tryb "lista"
                     inputCategory.classList.add('hidden');
                     selectCategory.classList.remove('hidden');
-                    inputCategory.value = '';
-                    rateInput.value     = '';
-                    rateInput.readOnly  = true;
+                    // Przywróć poprzednią lub pustą wartość
+                    selectCategory.value = '';
+                    inputCategory.value  = '';
+                    rateInput.value      = '';
+                    rateInput.readOnly   = true;
                     toggleBtn.textContent = 'Wpisz kategorię';
                 } else {
+                    // Tryb "ręcznie"
                     selectCategory.classList.add('hidden');
                     inputCategory.classList.remove('hidden');
+                    // Wyczyść wszystko, żeby wymusić manualne wpisanie
                     selectCategory.value = '';
-                    rateInput.value     = '';
-                    rateInput.readOnly  = false;
+                    inputCategory.value  = '';
+                    rateInput.value      = '';
+                    rateInput.readOnly   = false;
                     toggleBtn.textContent = 'Wybierz z listy';
                 }
             });
 
-            selectCategory.addEventListener('change', function () {
-                const cat = this.value;
+            selectCategory.addEventListener('change', () => {
+                const cat = selectCategory.value;
                 inputCategory.value = cat;
-                const rate = categoryRates[cat] ?? '';
-                rateInput.value     = rate;
+                rateInput.value     = categoryRates[cat] ?? '';
                 rateInput.readOnly  = true;
             });
 
-            // ————— DODATKOWA WALIDACJA FRONT-END —————
-            // Jeżeli wpiszesz ręcznie w pole kategorii nazwę istniejącą w mapie,
-            // to automatycznie zablokujemy edycję stawki na tę istniejącą wartość.
-            inputCategory.addEventListener('blur', function () {
-                const cat = this.value.trim();
-                if (!usingSelect && cat && categoryRates.hasOwnProperty(cat)) {
-                    // Kategoria istnieje — pobierz stawkę i zablokuj pole
-                    rateInput.value    = categoryRates[cat];
-                    rateInput.readOnly = true;
+            // Dodatkowo: jeśli wpiszesz ręcznie nazwę istniejącej kategorii,
+            // to zablokujemy stawkę i podmienimy ją na tę z mapy.
+            inputCategory.addEventListener('blur', () => {
+                const cat = inputCategory.value.trim();
+                if (!usingSelect && categoryRates.hasOwnProperty(cat)) {
+                    rateInput.value     = categoryRates[cat];
+                    rateInput.readOnly  = true;
                 } else if (!usingSelect) {
-                    // Nowa kategoria — pozwól edytować stawkę
-                    rateInput.value    = '';
-                    rateInput.readOnly = false;
+                    rateInput.readOnly  = false;
                 }
             });
         });

--- a/resources/views/admin/equipment/edit.blade.php
+++ b/resources/views/admin/equipment/edit.blade.php
@@ -14,106 +14,138 @@
             </div>
         @endif
 
-        <form action="{{ route('admin.equipment.update', $equipment->id) }}" method="POST" enctype="multipart/form-data" class="space-y-5">
+        {{-- Przygotuj mapę kategorii → stawek --}}
+        @php
+            use Illuminate\Support\Facades\DB;
+            $categoryRates = DB::table('equipment')
+                ->select('category', DB::raw('MAX(operator_rate) as rate'))
+                ->groupBy('category')
+                ->pluck('rate', 'category');
+        @endphp
+
+        <form action="{{ route('admin.equipment.update', $equipment->id) }}"
+              method="POST"
+              enctype="multipart/form-data"
+              class="space-y-5">
             @csrf
             @method('PUT')
 
+            {{-- Nazwa --}}
             <div>
                 <label class="block font-medium mb-1">Nazwa</label>
-                <input type="text" name="name" value="{{ old('name', $equipment->name) }}" required
+                <input type="text"
+                       name="name"
+                       value="{{ old('name', $equipment->name) }}"
+                       required
                        class="w-full rounded-lg border-gray-300 px-4 py-2 shadow-sm">
             </div>
 
+            {{-- Opis --}}
             <div>
                 <label class="block font-medium mb-1">Opis</label>
-                <textarea name="description" rows="4" required
+                <textarea name="description"
+                          rows="4"
+                          required
                           class="w-full rounded-lg border-gray-300 px-4 py-2 shadow-sm">{{ old('description', $equipment->description) }}</textarea>
             </div>
 
+            {{-- Dostępność --}}
             <div>
                 <label class="block font-medium mb-1">Dostępność</label>
                 <select name="availability" required
                         class="w-full rounded-lg border-gray-300 px-4 py-2 shadow-sm">
-                    @foreach (['dostepny', 'niedostepny', 'rezerwacja'] as $option)
-                        <option value="{{ $option }}" {{ old('availability', $equipment->availability) === $option ? 'selected' : '' }}>
-                            {{ ucfirst($option) }}
+                    @foreach (['dostepny','niedostepny','rezerwacja'] as $opt)
+                        <option value="{{ $opt }}"
+                            {{ old('availability', $equipment->availability) === $opt ? 'selected' : '' }}>
+                            {{ ucfirst($opt) }}
                         </option>
                     @endforeach
                 </select>
             </div>
 
+            {{-- Cena wynajmu --}}
             <div>
                 <label class="block font-medium mb-1">Cena wynajmu (zł)</label>
-                <input type="number" step="0.01" name="rental_price" value="{{ old('rental_price', $equipment->rental_price) }}" required
+                <input type="number" name="rental_price" step="0.01"
+                       value="{{ old('rental_price', $equipment->rental_price) }}"
+                       required
                        class="w-full rounded-lg border-gray-300 px-4 py-2 shadow-sm">
             </div>
 
+            {{-- Miniatura --}}
             <div>
-                <label class="block font-medium mb-1">Miniatura (podmień jeśli chcesz)</label>
+                <label class="block font-medium mb-1">Miniatura (zmień jeśli chcesz)</label>
                 <input type="file" name="thumbnail" accept=".webp"
                        class="w-full rounded-lg border-gray-300 px-3 py-2 file:bg-indigo-600 file:text-white file:px-4 file:py-2 file:rounded">
-                <p class="text-sm text-gray-500 mt-1">Obecna miniatura:</p>
-                <img src="{{ asset($equipment->thumbnail) }}" alt="miniatura" class="h-16 mt-2 rounded shadow">
+                <p class="text-sm text-gray-500 mt-2">Obecna:</p>
+                <img src="{{ asset($equipment->thumbnail) }}"
+                     class="h-16 rounded shadow mt-1" alt="miniatura">
             </div>
 
+            {{-- Zdjęcia dodatkowe --}}
             <div>
-                <label class="block font-medium mb-1">Dodaj więcej zdjęć (opcjonalnie)</label>
+                <label class="block font-medium mb-1">Dodaj zdjęcia (opcjonalnie)</label>
                 <input type="file" name="photos[]" accept=".webp" multiple
                        class="w-full rounded-lg border-gray-300 px-3 py-2 file:bg-indigo-600 file:text-white file:px-4 file:py-2 file:rounded">
             </div>
 
+            {{-- Stan techniczny --}}
             <div>
                 <label class="block font-medium mb-1">Stan techniczny</label>
                 <select name="technical_state" required
                         class="w-full rounded-lg border-gray-300 px-4 py-2 shadow-sm">
-                    @foreach (['nowy', 'uzywany', 'naprawa'] as $state)
-                        <option value="{{ $state }}" {{ old('technical_state', $equipment->technical_state) === $state ? 'selected' : '' }}>
-                            {{ ucfirst($state) }}
+                    @foreach (['nowy','uzywany','naprawa'] as $st)
+                        <option value="{{ $st }}"
+                            {{ old('technical_state', $equipment->technical_state) === $st ? 'selected' : '' }}>
+                            {{ ucfirst($st) }}
                         </option>
                     @endforeach
                 </select>
             </div>
 
+            {{-- Kategoria + stawka operatora --}}
             <div>
                 <label class="block font-medium mb-1">Kategoria</label>
-                <input type="text" name="category" value="{{ old('category', $equipment->category) }}" required
+
+                <button type="button" id="toggle-category-mode"
+                        class="mb-2 inline-flex items-center rounded-lg bg-blue-100 px-3 py-1 text-sm text-blue-700 hover:bg-blue-200">
+                    Wybierz z listy
+                </button>
+
+                <select id="existing-category"
+                        class="w-full hidden rounded-lg border-gray-300 px-4 py-2 mb-2 shadow-sm">
+                    <option value="">-- wybierz istniejącą --</option>
+                    @foreach($categoryRates->keys() as $cat)
+                        <option value="{{ $cat }}"
+                            {{ old('category', $equipment->category) === $cat ? 'selected' : '' }}>
+                            {{ $cat }}
+                        </option>
+                    @endforeach
+                </select>
+
+                <input type="text" name="category" id="category"
+                       placeholder="Wpisz kategorię"
+                       value="{{ old('category', $equipment->category) }}"
+                       required
                        class="w-full rounded-lg border-gray-300 px-4 py-2 shadow-sm">
             </div>
 
             <div>
-                <label class="block font-medium mb-1">Typ promocji</label>
-                <select name="promotion_type" id="promotion_type"
-                        class="w-full rounded-lg border-gray-300 px-4 py-2 shadow-sm"
-                    {{ $equipment->promotion_type === 'kategoria' ? 'disabled' : '' }}>
-                    <option value="">Brak</option>
-                    <option value="pojedyncza" {{ old('promotion_type', $equipment->promotion_type) === 'pojedyncza' ? 'selected' : '' }}>Pojedyncza</option>
-                    <option value="kategoria" {{ old('promotion_type', $equipment->promotion_type) === 'kategoria' ? 'selected' : '' }}>Kategoria (zablokowana)</option>
-                </select>
+                <label class="block font-medium mb-1">Stawka operatora (zł/dzień)</label>
+                <input type="number"
+                       name="operator_rate"
+                       id="operator_rate"
+                       step="0.01"
+                       min="0"
+                       value="{{ old('operator_rate', $equipment->operator_rate) }}"
+                       required
+                       class="w-full rounded-lg border-gray-300 px-4 py-2 shadow-sm @error('operator_rate') border-red-500 @enderror">
+                @error('operator_rate')
+                <p class="text-red-600 text-sm mt-1">{{ $message }}</p>
+                @enderror
             </div>
 
-            <div id="promo-fields"
-                 class="{{ $equipment->promotion_type === 'kategoria' ? 'hidden' : '' }}">
-                <div>
-                    <label class="block font-medium mb-1">Rabat (%)</label>
-                    <input type="number" name="discount" value="{{ old('discount', $equipment->discount) }}"
-                           class="w-full rounded-lg border-gray-300 px-4 py-2 shadow-sm">
-                </div>
-
-                <div>
-                    <label class="block font-medium mb-1">Data rozpoczęcia promocji</label>
-                    <input type="datetime-local" name="start_datetime"
-                           value="{{ old('start_datetime', $equipment->start_datetime ? \Carbon\Carbon::parse($equipment->start_datetime)->format('Y-m-d\TH:i') : '') }}"
-                           class="w-full rounded-lg border-gray-300 px-4 py-2 shadow-sm">
-                </div>
-
-                <div>
-                    <label class="block font-medium mb-1">Data zakończenia promocji</label>
-                    <input type="datetime-local" name="end_datetime"
-                           value="{{ old('end_datetime', $equipment->end_datetime ? \Carbon\Carbon::parse($equipment->end_datetime)->format('Y-m-d\TH:i') : '') }}"
-                           class="w-full rounded-lg border-gray-300 px-4 py-2 shadow-sm">
-                </div>
-            </div>
-
+            {{-- Submit --}}
             <div class="flex items-center gap-4 pt-4">
                 <button type="submit"
                         class="inline-flex items-center rounded-lg bg-green-600 px-5 py-2 text-white hover:bg-green-700">
@@ -131,18 +163,58 @@
 @push('scripts')
     <script>
         document.addEventListener('DOMContentLoaded', function () {
-            const promoType = document.getElementById('promotion_type');
-            const promoFields = document.getElementById('promo-fields');
+            const categoryRates = @json($categoryRates);
+            const toggleBtn      = document.getElementById('toggle-category-mode');
+            const selectCategory = document.getElementById('existing-category');
+            const inputCategory  = document.getElementById('category');
+            const rateInput      = document.getElementById('operator_rate');
 
-            if (promoType) {
-                promoType.addEventListener('change', function () {
-                    if (this.value === 'pojedyncza' || this.value === '') {
-                        promoFields.classList.remove('hidden');
-                    } else {
-                        promoFields.classList.add('hidden');
-                    }
-                });
-            }
+            let usingSelect = false;
+
+            toggleBtn.addEventListener('click', () => {
+                usingSelect = !usingSelect;
+
+                if (usingSelect) {
+                    // Tryb "lista"
+                    inputCategory.classList.add('hidden');
+                    selectCategory.classList.remove('hidden');
+                    // Przywróć poprzednią lub pustą wartość
+                    selectCategory.value = '';
+                    inputCategory.value  = '';
+                    rateInput.value      = '';
+                    rateInput.readOnly   = true;
+                    toggleBtn.textContent = 'Wpisz kategorię';
+                } else {
+                    // Tryb "ręcznie"
+                    selectCategory.classList.add('hidden');
+                    inputCategory.classList.remove('hidden');
+                    // Wyczyść wszystko, żeby wymusić manualne wpisanie
+                    selectCategory.value = '';
+                    inputCategory.value  = '';
+                    rateInput.value      = '';
+                    rateInput.readOnly   = false;
+                    toggleBtn.textContent = 'Wybierz z listy';
+                }
+            });
+
+            selectCategory.addEventListener('change', () => {
+                const cat = selectCategory.value;
+                inputCategory.value = cat;
+                rateInput.value     = categoryRates[cat] ?? '';
+                rateInput.readOnly  = true;
+            });
+
+            // Dodatkowo: jeśli wpiszesz ręcznie nazwę istniejącej kategorii,
+            // to zablokujemy stawkę i podmienimy ją na tę z mapy.
+            inputCategory.addEventListener('blur', () => {
+                const cat = inputCategory.value.trim();
+                if (!usingSelect && categoryRates.hasOwnProperty(cat)) {
+                    rateInput.value     = categoryRates[cat];
+                    rateInput.readOnly  = true;
+                } else if (!usingSelect) {
+                    rateInput.readOnly  = false;
+                }
+            });
         });
     </script>
 @endpush

--- a/resources/views/admin/operator_rates/edit.blade.php
+++ b/resources/views/admin/operator_rates/edit.blade.php
@@ -1,0 +1,42 @@
+@extends('layouts.admin')
+
+@section('admin-content')
+    <div class="container mx-auto py-8 max-w-md">
+        <h1 class="text-2xl font-bold mb-4">Edytuj stawkę operatora</h1>
+
+        <form method="POST"
+              action="{{ route('admin.operator-rates.update', urlencode($category)) }}">
+            @csrf
+            @method('PUT')
+
+            <div class="mb-4">
+                <label class="block font-medium mb-1">Kategoria</label>
+                <input type="text"
+                       value="{{ $category }}"
+                       disabled
+                       class="w-full border p-2 rounded bg-gray-100 cursor-not-allowed">
+            </div>
+
+            <div class="mb-4">
+                <label for="operator_rate" class="block font-medium mb-1">Stawka operatora (zł/dzień)</label>
+                <input type="number"
+                       step="0.01"
+                       min="0"
+                       name="operator_rate"
+                       id="operator_rate"
+                       value="{{ old('operator_rate', $current_operator_rate) }}"
+                       class="w-full border p-2 rounded @error('operator_rate') border-red-500 @enderror">
+                @error('operator_rate')
+                <p class="text-red-600 text-sm mt-1">{{ $message }}</p>
+                @enderror
+            </div>
+
+            <button type="submit"
+                    class="bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-4 rounded">
+                Zapisz
+            </button>
+            <a href="{{ route('admin.operator-rates.index') }}"
+               class="ml-4 text-gray-600 hover:underline">Anuluj</a>
+        </form>
+    </div>
+@endsection

--- a/resources/views/admin/operator_rates/index.blade.php
+++ b/resources/views/admin/operator_rates/index.blade.php
@@ -1,0 +1,35 @@
+@extends('layouts.admin') {{-- Twój layout panelu admina --}}
+
+@section('admin-content')
+    <div class="container mx-auto py-8">
+        <h1 class="text-2xl font-bold mb-4">Stawki operatora wg kategorii</h1>
+
+        @if(session('success'))
+            <div class="bg-green-100 text-green-800 p-3 rounded mb-4">
+                {{ session('success') }}
+            </div>
+        @endif
+
+        <table class="min-w-full bg-white shadow rounded">
+            <thead>
+            <tr>
+                <th class="px-4 py-2 text-left">Kategoria sprzętu</th>
+                <th class="px-4 py-2 text-right">Operator (zł/dzień)</th>
+                <th class="px-4 py-2"></th>
+            </tr>
+            </thead>
+            <tbody>
+            @foreach($rates as $rate)
+                <tr class="border-t">
+                    <td class="px-4 py-2">{{ $rate->category }}</td>
+                    <td class="px-4 py-2 text-right">{{ number_format($rate->operator_rate,2,',',' ') }}</td>
+                    <td class="px-4 py-2 text-right">
+                        <a href="{{ route('admin.operator-rates.edit', urlencode($rate->category)) }}"
+                           class="text-indigo-600 hover:underline">Edytuj</a>
+                    </td>
+                </tr>
+            @endforeach
+            </tbody>
+        </table>
+    </div>
+@endsection

--- a/resources/views/components/admin-navbar.blade.php
+++ b/resources/views/components/admin-navbar.blade.php
@@ -29,6 +29,8 @@
                        class="block px-4 py-2 text-[#f56600] border-b border-[#f56600]">Dodaj sprzęt</a></li>
                 <li><a href="{{ route('admin.equipment.index') }}"
                        class="block px-4 py-2 text-[#f56600] border-b border-[#f56600]">Lista sprzętu</a></li>
+                <li><a href="{{ route('admin.operator-rates.index') }}"
+                       class="block px-4 py-2 text-[#f56600] border-b">Pracownicy</a></li>
             </ul>
         </li>
 

--- a/resources/views/rentals/payment.blade.php
+++ b/resources/views/rentals/payment.blade.php
@@ -5,60 +5,102 @@
         <h1 class="text-3xl font-bold mb-6">Płatność za wypożyczenie sprzętu</h1>
 
         <div class="bg-white p-6 rounded shadow max-w-lg mx-auto">
-            <p><strong>Sprzęt:</strong>
-                {{ $rental->equipment->name }}
+            @php
+                // Pobieramy dane z sesji, które zapisaliśmy w store()
+                $data = session('rental_data', []);
+                $equipment = $rental->equipment;
 
-                @if($rental->with_operator)
+                $days              = $data['days']                   ?? 0;
+                $dailyEqRate       = $data['equipment_daily_rate']   ?? 0;
+                $equipmentCost     = $data['equipment_cost']         ?? 0;
+                $operatorDailyRate = $data['operator_daily_rate']    ?? 0;
+                $operatorCost      = $data['operator_cost']          ?? 0;
+                $totalCost         = $data['total_price']            ?? 0;
+                $notes             = $data['notes']                  ?? null;
+            @endphp
+
+            <p>
+                <strong>Sprzęt:</strong> {{ $equipment->name }}
+                @if($data['with_operator'] ?? false)
                     <span class="text-sm text-gray-600">+ operator</span>
                 @endif
             </p>
-            <p><strong>Okres wypożyczenia:</strong> {{ $rental->start_date->format('Y-m-d') }} – {{ $rental->end_date->format('Y-m-d') }}</p>
 
-            @php
-                $days = $rental->start_date->diffInDays($rental->end_date) + 1;
-                $dailyPrice = $rental->equipment->finalPrice();
-                $equipmentCost = round($days * $dailyPrice, 2);
-                $operatorCost = $rental->with_operator ? round($days * 350, 2) : 0;
-                $totalCost = $rental->total_price;
-            @endphp
+            @if($notes)
+                <p><em class="text-sm text-gray-500">{{ $notes }}</em></p>
+            @endif
 
-            <p><strong>Łączna kwota:</strong> <span class="text-lg font-semibold">{{ number_format($totalCost, 2, ',', ' ') }} zł</span></p>
+            <p class="mt-2">
+                <strong>Okres wypożyczenia:</strong>
+                {{ $data['start_date'] }} – {{ $data['end_date'] }}
+            </p>
 
-            <div class="text-sm text-gray-600 mt-2 mb-4">
-                <p>{{ $days }} dni × {{ number_format($dailyPrice, 2, ',', ' ') }} zł = {{ number_format($equipmentCost, 2, ',', ' ') }} zł</p>
-                @if($rental->with_operator)
-                    <p>{{ $days }} dni × 350 zł = {{ number_format($operatorCost, 2, ',', ' ') }} zł</p>
+            <p class="mt-4">
+                <strong>Łączna kwota:</strong>
+                <span class="text-lg font-semibold">{{ number_format($totalCost, 2, ',', ' ') }} zł</span>
+            </p>
+
+            <div class="text-sm text-gray-600 mt-2 mb-4 space-y-1">
+                <p>
+                    {{ $days }} dni × {{ number_format($dailyEqRate, 2, ',', ' ') }} zł =
+                    {{ number_format($equipmentCost, 2, ',', ' ') }} zł
+                </p>
+                @if($data['with_operator'] ?? false)
+                    <p>
+                        {{ $days }} dni × {{ number_format($operatorDailyRate, 2, ',', ' ') }} zł =
+                        {{ number_format($operatorCost, 2, ',', ' ') }} zł
+                    </p>
                 @endif
             </div>
 
             @if(Auth::user()->account_balance >= $totalCost)
-                <form method="POST" action="{{ route('client.rentals.processPayment', $rental) }}" class="mt-6">
+                <form method="POST" action="{{ route('client.rentals.processPayment') }}" class="mt-6">
                     @csrf
-                    <button type="submit" class="bg-[#f56600] hover:bg-[#f98800] text-white font-semibold py-2 px-6 rounded w-full">
+                    <button
+                        type="submit"
+                        class="bg-[#f56600] hover:bg-[#f98800] text-white font-semibold py-2 px-6 rounded w-full"
+                    >
                         Zapłać i potwierdź wypożyczenie
                     </button>
                 </form>
             @else
                 <div class="flex flex-col gap-4 mt-6">
-                    <a href="{{ route('client.account.topup.form') }}" class="bg-red-600 hover:bg-red-700 text-white font-semibold py-2 px-6 rounded w-full text-center">
+                    <a
+                        href="{{ route('client.account.topup.form') }}"
+                        class="bg-red-600 hover:bg-red-700 text-white font-semibold py-2 px-6 rounded w-full text-center"
+                    >
                         Brak środków – Doładuj konto
                     </a>
 
-                    <form method="POST" action="#" class="bg-yellow-100 p-4 rounded shadow-inner">
+                    {{-- Formularz na kod BIWO --}}
+                    <form
+                        method="POST"
+                        action="{{ route('client.rentals.payWithBiwo') }}"
+                        class="bg-yellow-100 p-4 rounded shadow-inner"
+                    >
                         @csrf
-                        <label for="code" class="block text-sm font-medium text-gray-700 mb-1">Lub zapłąć kodem BIWO</label>
-                        <input type="text" name="code" id="code" required
-                               class="border p-2 rounded w-full mb-3"
-                               placeholder="Wpisz kod BIWO">
-
-                        <button type="submit"
-                                class="bg-red-600 hover:bg-red-700 text-white font-semibold py-2 px-6 rounded w-full text-center">
+                        <label for="code" class="block text-sm font-medium mb-1">
+                            Lub zapłać kodem BIWO
+                        </label>
+                        <input
+                            type="text"
+                            name="code"
+                            id="code"
+                            required
+                            class="border p-2 rounded w-full mb-3"
+                            placeholder="Wpisz kod BIWO"
+                        >
+                        <button
+                            type="submit"
+                            class="bg-red-600 hover:bg-red-700 text-white font-semibold py-2 px-6 rounded w-full"
+                        >
                             Zapłać kodem BIWO
                         </button>
                     </form>
 
                     <p class="text-sm text-gray-600 text-center">
-                        Masz {{ number_format(Auth::user()->account_balance, 2, ',', ' ') }} zł – potrzebujesz {{ number_format($totalCost, 2, ',', ' ') }} zł
+                        Masz {{ number_format(Auth::user()->account_balance, 2, ',', ' ') }} zł –
+                        potrzebujesz {{ number_format($totalCost, 2, ',', ' ') }} zł
                     </p>
                 </div>
             @endif

--- a/resources/views/rentals/summary.blade.php
+++ b/resources/views/rentals/summary.blade.php
@@ -40,7 +40,6 @@
                         class="border p-2 rounded block mb-4 w-full"
                     >
 
-                    {{-- Checkbox: czy potrzebujesz operatora --}}
                     <div class="mb-4">
                         <input
                             type="checkbox"
@@ -54,8 +53,9 @@
 
                     <p id="total_price" class="font-semibold text-lg mb-4 hidden"></p>
 
-                    <button type="submit" class="bg-[#f56600] hover:bg-[#f98800] text-white font-semibold py-2 px-6 rounded w-full">
-                        Potwierdź zamówienie
+                    <button type="submit"
+                            class="bg-[#f56600] hover:bg-[#f98800] text-white font-semibold py-2 px-6 rounded w-full">
+                        Podsumowanie i płatność
                     </button>
                 </form>
             </div>
@@ -64,23 +64,26 @@
 
     <script>
         document.addEventListener('DOMContentLoaded', () => {
-            const startInput = document.getElementById('start_date');
-            const endInput = document.getElementById('end_date');
-            const withOperatorInput = document.getElementById('with_operator');
-            const totalPriceEl = document.getElementById('total_price');
-            const dailyPrice = {{ $equipment->finalPrice() }};
-            const operatorDaily = 350;
+            const startInput       = document.getElementById('start_date');
+            const endInput         = document.getElementById('end_date');
+            const withOperatorInput= document.getElementById('with_operator');
+            const totalPriceEl     = document.getElementById('total_price');
+
+            // cena sprzętu i stawka operatora pobrane z bazy
+            const dailyPrice    = {{ $equipment->finalPrice() }};
+            const operatorDaily = {{ $equipment->operator_daily_rate }};
 
             function updateTotalPrice() {
                 const start = new Date(startInput.value);
-                const end = new Date(endInput.value);
+                const end   = new Date(endInput.value);
 
                 if (start && end && end >= start) {
-                    const diffTime = end - start;
-                    const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24)) + 1;
-
-                    const baseCost = diffDays * dailyPrice;
-                    const operatorCost = withOperatorInput.checked ? diffDays * operatorDaily : 0;
+                    const diffTime     = end - start;
+                    const diffDays     = Math.floor(diffTime / (1000 * 60 * 60 * 24)) + 1;
+                    const baseCost     = diffDays * dailyPrice;
+                    const operatorCost = withOperatorInput.checked
+                        ? diffDays * operatorDaily
+                        : 0;
                     const total = (baseCost + operatorCost).toFixed(2);
 
                     const breakdown = [
@@ -88,10 +91,15 @@
                     ];
 
                     if (withOperatorInput.checked) {
-                        breakdown.push(`${diffDays} dni × 350 zł = ${operatorCost.toFixed(2).replace('.', ',')} zł`);
+                        breakdown.push(
+                            `${diffDays} dni × ${operatorDaily.toFixed(2).replace('.', ',')} zł = ${operatorCost.toFixed(2).replace('.', ',')} zł`
+                        );
                     }
 
-                    totalPriceEl.innerHTML = `Cena całkowita: <strong>${total.replace('.', ',')} zł</strong><br><small>${breakdown.join('<br>')}</small>`;
+                    totalPriceEl.innerHTML = `
+            Cena całkowita: <strong>${total.replace('.', ',')} zł</strong><br>
+            <small>${breakdown.join('<br>')}</small>
+          `;
                     totalPriceEl.classList.remove('hidden');
                 } else {
                     totalPriceEl.textContent = '';
@@ -108,10 +116,8 @@
                 }
                 updateTotalPrice();
             });
-
             endInput.addEventListener('change', updateTotalPrice);
             withOperatorInput.addEventListener('change', updateTotalPrice);
         });
     </script>
-
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -77,4 +77,13 @@ Route::prefix('admin/dashboard')->name('admin.')->middleware(['auth', 'verified'
     });
 });
 
+Route::prefix('admin')->middleware(['auth'])->name('admin.')->group(function() {
+    Route::get('operator-rates',        [\App\Http\Controllers\Admin\OperatorRateController::class, 'index'])
+        ->name('operator-rates.index');
+    Route::get('operator-rates/{category}/edit', [\App\Http\Controllers\Admin\OperatorRateController::class, 'edit'])
+        ->name('operator-rates.edit');
+    Route::put('operator-rates/{category}',      [\App\Http\Controllers\Admin\OperatorRateController::class, 'update'])
+        ->name('operator-rates.update');
+});
+
 require __DIR__.'/auth.php';


### PR DESCRIPTION
Client-side:
- Added functionality to allow ordering staff for rented equipment.
- Price calculation for operator fees based on the selected staff type and equipment complexity.

Admin-side:
- Updated the model and migrations to include operator fees assigned to specific equipment categories.
- Added a view and logic for managing operator fees in the admin panel.
- Prevented the assignment of different operator fees to the same equipment category.
- Enabled admin to edit and assign operator fees to specific equipment categories.