### PR TITLE
Add Promotion Terms and Conditions to the Page

### DIFF
--- a/app/Http/Controllers/ClientRentalController.php
+++ b/app/Http/Controllers/ClientRentalController.php
@@ -7,41 +7,75 @@ use Illuminate\Support\Facades\Auth;
 use App\Models\Rental;
 use App\Models\Equipment;
 use Carbon\Carbon;
+use App\Http\Controllers\LoyalCustomerPromotionController;
+
 
 class ClientRentalController extends Controller
 {
+    private function getLoyalDiscount(int $currentRentalsCount): int
+    {
+        // 1) Pierwsze wypożyczenie (rentals_count == 0) → 20%
+        if ($currentRentalsCount === 0) {
+            return 20;
+        }
+        // 2) Co 20-te wypożyczenie → 50%
+        if ((($currentRentalsCount + 1) % 20) === 0) {
+            return 50;
+        }
+        // 3) Co 5-te (ale nie 20-te) → 25%
+        if ((($currentRentalsCount + 1) % 5) === 0) {
+            return 25;
+        }
+        // 4) Inne przypadki → brak rabatu
+        return 0;
+    }
+
     public function store(Request $request)
     {
+        // Walidacja pól
         $request->validate([
-            'equipment_id' => 'required|exists:equipment,id',
-            'start_date' => 'required|date|after_or_equal:today',
-            'end_date' => 'required|date|after_or_equal:start_date',
+            'equipment_id'      => 'required|exists:equipment,id',
+            'start_date'        => 'required|date|after_or_equal:today',
+            'end_date'          => 'required|date|after_or_equal:start_date',
+            'with_operator'     => 'sometimes|boolean',
         ]);
 
         $equipment = Equipment::findOrFail($request->equipment_id);
 
+        // Obliczamy dni wypożyczenia
         $start = Carbon::parse($request->start_date);
         $end   = Carbon::parse($request->end_date);
         $days  = $start->diffInDays($end) + 1;
 
-        // ceny jednostkowe
+        // Stawki
         $dailyEq      = $equipment->finalPrice();
         $operatorRate = $equipment->operator_daily_rate;
 
-        // koszty
+        // Surowe koszty
         $equipmentCost = round($days * $dailyEq, 2);
         $operatorCost  = $request->has('with_operator')
             ? round($days * $operatorRate, 2)
             : 0;
 
-        $total = round($equipmentCost + $operatorCost, 2);
+        $rawTotal = round($equipmentCost + $operatorCost, 2);
 
-        // przygotuj notatki
+        // 1) Pobieramy liczbę dotychczasowych wypożyczeń użytkownika
+        $user = Auth::user();
+        $currentRentalsCount = $user->rentals_count;
+
+        // 2) Wyliczamy procent rabatu lojalnościowego
+        $discountPercent = $this->getLoyalDiscount($currentRentalsCount);
+
+        // 3) Wyliczamy kwotę rabatu i kwotę po rabacie
+        $discountAmount  = round($rawTotal * ($discountPercent / 100), 2);
+        $discountedTotal = round($rawTotal - $discountAmount, 2);
+
+        // Notatki (opcjonalnie)
         $notes = $request->has('with_operator')
             ? 'Wypożyczenie z operatorem'
             : null;
 
-        // zapisz wszystko w sesji
+        // Zapisujemy do sesji wszystkie niezbędne dane
         session([
             'rental_data' => [
                 'equipment_id'         => $equipment->id,
@@ -53,7 +87,10 @@ class ClientRentalController extends Controller
                 'equipment_cost'       => $equipmentCost,
                 'operator_daily_rate'  => $operatorRate,
                 'operator_cost'        => $operatorCost,
-                'total_price'          => $total,
+                // Tym razem 'total_price' = wartość PO rabacie:
+                'total_price'          => $discountedTotal,
+                'discount_percent'     => $discountPercent,
+                'discount_amount'      => $discountAmount,
                 'notes'                => $notes,
             ]
         ]);
@@ -79,33 +116,41 @@ class ClientRentalController extends Controller
     public function payment()
     {
         $data = session('rental_data');
-
         if (! $data) {
             return redirect()
                 ->route('client.rentals.index')
                 ->withErrors('Brak danych do wypożyczenia.');
         }
 
+        // Ładujemy Equipment i „tymczasowy” Rental, by mieć relację equipment itp.
         $equipment = Equipment::findOrFail($data['equipment_id']);
-
         $rental = new Rental([
             'equipment_id'  => $equipment->id,
             'start_date'    => $data['start_date'],
             'end_date'      => $data['end_date'],
             'with_operator' => $data['with_operator'],
             'notes'         => $data['notes'] ?? null,
+            // Ta wartość jest już price po rabacie:
             'total_price'   => $data['total_price'],
         ]);
-
         $rental->setRelation('equipment', $equipment);
 
-        return view('rentals.payment', compact('rental'));
+        // Pobieramy z sesji to, co zapisaliśmy wcześniej:
+        $totalPrice      = $data['total_price'];         // kwota PO rabacie
+        $discountPercent = $data['discount_percent']     ?? 0;
+        $discountAmount  = $data['discount_amount']      ?? 0;
+
+        return view('rentals.payment', compact(
+            'rental',
+            'totalPrice',
+            'discountPercent',
+            'discountAmount'
+        ));
     }
 
     public function processPayment(Request $request)
     {
         $data = session('rental_data');
-
         if (! $data) {
             return redirect()
                 ->route('client.rentals.index')
@@ -113,7 +158,6 @@ class ClientRentalController extends Controller
         }
 
         $equipment = Equipment::findOrFail($data['equipment_id']);
-
         if (! $equipment->isAvailable()) {
             return redirect()
                 ->route('client.rentals.index')
@@ -122,15 +166,22 @@ class ClientRentalController extends Controller
 
         $user = Auth::user();
 
-        if ($user->account_balance < $data['total_price']) {
+        // 1) Pobieramy z requesta ostateczną kwotę do zapłaty (już po rabacie)
+        //    Tę samą, którą zapisaliśmy w sesji jako 'total_price'
+        $finalPrice = $request->input('total_price');
+
+        // 2) Sprawdzamy saldo
+        if ($user->account_balance < $finalPrice) {
             return redirect()
-                ->route('client.rentals.topup')
-                ->with('not_enough', true);
+                ->route('client.rentals.payment')
+                ->withErrors('Brak wystarczających środków na koncie.');
         }
 
-        $user->account_balance = round($user->account_balance - $data['total_price'], 2);
+        // 3) Odejmujemy od salda
+        $user->account_balance = round($user->account_balance - $finalPrice, 2);
         $user->save();
 
+        // 4) Tworzymy Rental z zachowaniem zapłaty po rabacie
         $rental = Rental::create([
             'user_id'           => $user->id,
             'equipment_id'      => $equipment->id,
@@ -139,18 +190,22 @@ class ClientRentalController extends Controller
             'status'            => 'oczekujace',
             'notes'             => $data['notes'] ?? null,
             'payment_reference' => 'fake_payment_token_' . uniqid(),
-            'total_price'       => $data['total_price'],
+            'total_price'       => $finalPrice,
             'with_operator'     => $data['with_operator'],
+            // Jeśli chcesz, możesz dodać:
+            // 'discount_percent' => $data['discount_percent'],
+            // 'discount_amount'  => $data['discount_amount'],
         ]);
 
         $equipment->availability = 'niedostepny';
         $equipment->save();
 
+        // 5) Zapomnij dane sesji
         session()->forget('rental_data');
 
         return redirect()
             ->route('client.rentals.index')
-            ->with('success', 'Płatność została zaakceptowana, wypożyczenie oczekuje na akceptacje.');
+            ->with('success', 'Płatność została zaakceptowana, wypożyczenie oczekuje na akceptację.');
     }
 
     public function cancel(Rental $rental)

--- a/resources/views/components/footer.blade.php
+++ b/resources/views/components/footer.blade.php
@@ -23,6 +23,7 @@
                 <li><a href="#" class="hover:underline text-orange-400" id="about_us">O nas</a></li>
                 <li><a href="#" class="hover:underline text-orange-400">Regulamin</a></li>
                 <li><a href="#" class="hover:underline text-orange-400">Polityka prywatności</a></li>
+                <li><a href="{{route('promotions.rules')}}" class="hover:underline text-orange-400">Regulamin promocji</a></li>
             </ul>
         </div>
 

--- a/resources/views/equipments/show.blade.php
+++ b/resources/views/equipments/show.blade.php
@@ -1,9 +1,34 @@
+{{-- resources/views/rentals/show.blade.php --}}
+
 @extends('layouts.app')
 
 @section('content')
     <section class="max-w-[1140px] mx-auto px-4 py-12 max-md:px-0">
+        @php
+            // Obliczamy rabat lojalnościowy na podstawie dotychczasowych wypożyczeń:
+            $rentalsCount = Auth::user()->rentals_count ?? 0;
+            if ($rentalsCount === 0) {
+                $discountPercent = 20;
+            } elseif ((($rentalsCount + 1) % 20) === 0) {
+                $discountPercent = 50;
+            } elseif ((($rentalsCount + 1) % 5) === 0) {
+                $discountPercent = 25;
+            } else {
+                $discountPercent = 0;
+            }
+        @endphp
+
+        {{-- Banner z informacją o zniżce lojalnościowej --}}
+        @if($discountPercent > 0)
+            <div class="mb-6 p-4 bg-blue-50 border border-blue-200 rounded-md text-center">
+                <p class="text-lg text-blue-700 font-semibold">
+                    Otrzymujesz <span class="text-2xl">{{ $discountPercent }}%</span> zniżki na to wypożyczenie.
+                </p>
+            </div>
+        @endif
+
         <div class="flex max-md:flex-col bg-white p-10 max-sm:p-4 rounded-md shadow-md">
-            <div class="max-h-[500px] max-md:w-full lg:mr-14 max-md:mr-2  w-1/2">
+            <div class="max-h-[500px] max-md:w-full lg:mr-14 max-md:mr-2 w-1/2">
                 <h1 class="text-4xl font-bold mb-4 text-center">{{ $equipment->name }}</h1>
                 <div id="slider" class="relative w-full max-w-xl mx-auto">
                     <img id="slider-image"
@@ -74,7 +99,7 @@
                         </form>
                     @else
                         <span class="italic">
-                                Produkt nie dostępny
+                            Produkt nie dostępny
                         </span>
                     @endif
                 </div>
@@ -93,45 +118,29 @@
                 @endforeach
             ];
 
-            console.log('Photos array:', photos); // logujemy tablicę
-
             let current = 0;
 
             function showSlide(index) {
-                console.log('Trying to show slide index:', index);
                 const img = document.getElementById('slider-image');
-                if (!img) {
-                    console.error('Slider image element not found!');
-                    return;
+                if (photos[index]) {
+                    img.src = photos[index];
                 }
-
-                if (!photos[index]) {
-                    console.warn('No photo at index:', index);
-                    return;
-                }
-
-                console.log('Setting image source to:', photos[index]);
-                img.src = photos[index];
             }
 
             function nextSlide() {
                 current = (current + 1) % photos.length;
-                console.log('Next slide:', current);
                 showSlide(current);
             }
 
             function prevSlide() {
                 current = (current - 1 + photos.length) % photos.length;
-                console.log('Previous slide:', current);
                 showSlide(current);
             }
 
             window.nextSlide = nextSlide;
             window.prevSlide = prevSlide;
 
-            showSlide(current); // inicjalizacja
+            showSlide(current);
         });
     </script>
-
 @endpush
-

--- a/resources/views/promotions/rules.blade.php
+++ b/resources/views/promotions/rules.blade.php
@@ -1,0 +1,254 @@
+@extends('layouts.app')
+
+@section('content')
+    <section class="max-w-[800px] mx-auto px-4 py-12">
+        <h1 class="text-4xl font-bold mb-6 text-center">Regulamin Promocji</h1>
+
+        {{-- 1. Postanowienia ogólne --}}
+        <div class="mb-10 p-6 bg-white rounded-lg shadow">
+            <h2 class="text-2xl font-semibold mb-3">1. Postanowienia ogólne</h2>
+            <p class="mb-3 text-gray-700">
+                1.1. Niniejszy Regulamin określa zasady, zakres oraz warunki przyznawania i łączenia promocji obowiązujących w serwisie świadczącym usługi wypożyczania sprzętu („Serwis”).
+            </p>
+            <p class="mb-3 text-gray-700">
+                1.2. Promocje opisane w niniejszym Regulaminie mogą dotyczyć:
+            </p>
+            <ul class="list-disc list-inside mb-3 text-gray-700">
+                <li>a) Promocji lojalnościowej,</li>
+                <li>b) Promocji pojedynczych produktów,</li>
+                <li>c) Promocji na kategorie sprzętu.</li>
+            </ul>
+            <p class="mb-3 text-gray-700">
+                1.3. Wszystkie promocje są przyznawane zgodnie z ustalonymi poniżej zasadami, a ich istotą jest obniżenie ceny wypożyczenia lub zakupu sprzętu (dalej także: „Rabat”).
+            </p>
+            <p class="mb-3 text-gray-700">
+                1.4. Regulamin obowiązuje od momentu jego opublikowania i stosuje się do wszystkich transakcji zawieranych od dnia wejścia regulaminu w życie, chyba że w ramach poszczególnych promocji określono inne daty obowiązywania.
+            </p>
+            <p class="mb-3 text-gray-700">
+                1.5. Administrator Serwisu (dalej: „Administrator”) zastrzega sobie prawo do czasowego zawieszenia, modyfikacji lub zakończenia trwania promocji określonych w niniejszym Regulaminie. Wszelkie zmiany w regulaminie będą publikowane na stronie Serwisu.
+            </p>
+        </div>
+
+        {{-- 2. Definicje --}}
+        <div class="mb-10 p-6 bg-white rounded-lg shadow">
+            <h2 class="text-2xl font-semibold mb-3">2. Definicje</h2>
+            <p class="mb-3 text-gray-700">
+                2.1. <strong>Użytkownik</strong> – osoba fizyczna lub prawna, która dokonuje rejestracji w Serwisie, korzysta z usług Serwisu oraz zawiera transakcje wypożyczenia sprzętu.
+            </p>
+            <p class="mb-3 text-gray-700">
+                2.2. <strong>rentals_count</strong> – pole w Karcie Użytkownika, wskazujące liczbę zakończonych wypożyczeń dokonanych przez Użytkownika.
+            </p>
+            <p class="mb-3 text-gray-700">
+                2.3. <strong>Sprzęt (Equipment)</strong> – przedmiot wypożyczenia lub sprzedaży dostępny w Serwisie, zdefiniowany przez unikalny identyfikator oraz cenę bazową (<code>OriginalPrice</code>).
+            </p>
+            <p class="mb-3 text-gray-700">
+                2.4. <strong>Kategoria sprzętu (category)</strong> – przyporządkowana Użytkownikowi klasyfikacja, np. „Kamery”, „Laptopy” itp., określająca grupę produktów w Serwisie.
+            </p>
+            <p class="mb-3 text-gray-700">
+                2.5. <strong>Promocja lojalnościowa</strong> – promocja naliczana na podstawie liczby zakończonych wypożyczeń (rentals_count) przez Użytkownika.
+            </p>
+            <p class="mb-3 text-gray-700">
+                2.6. <strong>Promocja pojedynczego produktu</strong> – promocja przypisana wyłącznie do konkretnego sprzętu.
+            </p>
+            <p class="mb-3 text-gray-700">
+                2.7. <strong>Promocja na kategorię sprzętu</strong> – promocja przypisana do wszystkich sprzętów w ramach jednej kategorii.
+            </p>
+            <p class="mb-3 text-gray-700">
+                2.8. <strong>Rabat</strong> – procentowa obniżka ceny bazowej sprzętu, wyrażona w wartościach od 0% do 100%.
+            </p>
+            <p class="mb-3 text-gray-700">
+                2.9. <strong>Okres promocyjny</strong> – przedział czasowy wyznaczony przez Administratora, w jakim dana promocja jest aktywna, określony w polach <code>start_datetime</code> (data i godzina rozpoczęcia) oraz <code>end_datetime</code> (data i godzina zakończenia).
+            </p>
+            <p class="mb-3 text-gray-700">
+                2.10. <strong>promotion_type</strong> – pole w modelu <code>Equipment</code>, przyjmujące wartości:
+            </p>
+            <ul class="list-disc list-inside mb-3 text-gray-700">
+                <li>a) <code>‘pojedyncza’</code> – w odniesieniu do promocji przypisanej do konkretnego sprzętu,</li>
+                <li>b) <code>‘kategoria’</code> – w odniesieniu do promocji obejmującej wszystkie produkty w danej kategorii,</li>
+                <li>c) brak wartości – w przypadku braku aktywnej promocji pojedynczej lub kategorii.</li>
+            </ul>
+        </div>
+
+        {{-- 3. Promocja lojalnościowa --}}
+        <div class="mb-10 p-6 bg-white rounded-lg shadow">
+            <h2 class="text-2xl font-semibold mb-3">3. Promocja lojalnościowa</h2>
+            <p class="mb-3 text-gray-700">
+                3.1. Prawo do skorzystania z Promocji lojalnościowej przysługuje zarejestrowanym Użytkownikom Serwisu.
+            </p>
+            <p class="mb-3 text-gray-700">
+                3.2. Promocja lojalnościowa naliczana jest na podstawie wartości pola <code>rentals_count</code> w Karcie Użytkownika, oznaczającego liczbę zakończonych wypożyczeń, o ile dane wypożyczenie zostało w pełni rozliczone („Zakończone wypożyczenie”).
+            </p>
+            <p class="mb-3 text-gray-700">
+                3.3. Rabaty w ramach Promocji lojalnościowej przyznawane są według następujących reguł:
+            </p>
+            <ul class="list-disc list-inside mb-3 text-gray-700">
+                <li>
+                    <strong>Pierwsze wypożyczenie</strong> (rentals_count == 0): rabat w wysokości <span class="font-semibold">20%</span> od ceny bazowej sprzętu.
+                </li>
+                <li>
+                    <strong>Każde piąte wypożyczenie</strong> (tj. rentals_count + 1 jest wielokrotnością 5, lecz różne od 20): rabat w wysokości <span class="font-semibold">25%</span> od ceny bazowej sprzętu.
+                </li>
+                <li>
+                    <strong>Każde dwudzieste wypożyczenie</strong> (tj. rentals_count + 1 jest wielokrotnością 20): rabat w wysokości <span class="font-semibold">50%</span> od ceny bazowej sprzętu.
+                </li>
+                <li>
+                    <strong>Pozostałe przypadki</strong>: brak rabatu.
+                </li>
+            </ul>
+            <p class="mb-3 text-gray-700">
+                3.4. Przykład:
+            </p>
+            <ul class="list-disc list-inside mb-3 text-gray-700">
+                <li>Jeżeli Użytkownik ma zakończonych 4 wypożyczenia (rentals_count == 4), to przy kolejnym piątym wypożyczeniu otrzymuje rabat 25%.</li>
+                <li>Jeżeli Użytkownik ma zakończonych 19 wypożyczeń (rentals_count == 19), to przy kolejnym dwudziestym wypożyczeniu otrzymuje rabat 50%.</li>
+            </ul>
+            <p class="mb-3 text-gray-700">
+                3.5. Promocja lojalnościowa stosowana jest dopiero w sytuacjach, gdy na dany sprzęt nie obowiązuje Promocja pojedyncza ani Promocja na kategorię (zob. § 6).
+            </p>
+            <p class="text-gray-500 text-sm">
+                3.6. Promocja lojalnościowa jest bezterminowa i nie wymaga odrębnej rejestracji ze strony Użytkownika, pod warunkiem posiadania wymaganej liczby zakończonych wypożyczeń.
+            </p>
+        </div>
+
+        {{-- 4. Promocje pojedynczych produktów --}}
+        <div class="mb-10 p-6 bg-white rounded-lg shadow">
+            <h2 class="text-2xl font-semibold mb-3">4. Promocje pojedynczych produktów</h2>
+            <p class="mb-3 text-gray-700">
+                4.1. Promocja pojedyncza dotyczy wyłącznie konkretnego sprzętu i jest definiowana następującymi parametrami:
+            </p>
+            <ul class="list-disc list-inside mb-3 text-gray-700">
+                <li><strong>start_datetime</strong> – data i godzina rozpoczęcia Promocji pojedynczej,</li>
+                <li><strong>end_datetime</strong> – data i godzina zakończenia Promocji pojedynczej,</li>
+                <li><strong>discount</strong> – procent rabatu w odniesieniu do ceny bazowej sprzętu,</li>
+                <li><strong>promotion_type</strong> – ustawiana w modelu <code>Equipment</code> wartość <code>'pojedyncza'</code>.</li>
+            </ul>
+            <p class="mb-3 text-gray-700">
+                4.2. W przypadku aktywnej Promocji pojedynczej (tj. gdy bieżący czas mieści się w przedziale [<code>start_datetime</code>, <code>end_datetime</code>] włącznie), cena wyświetlana w Serwisie obliczana jest według wzoru:
+            </p>
+            <pre class="bg-gray-100 p-4 rounded text-sm text-gray-800 mb-3">OriginalPrice × (1 – discount/100)</pre>
+            <p class="mb-3 text-gray-700">
+                4.3. Po upływie <code>end_datetime</code> Promocja pojedyncza wygasa automatycznie. Wówczas pola <code>promotion_type</code>, <code>start_datetime</code>, <code>end_datetime</code> oraz <code>discount</code> w modelu <code>Equipment</code> zostają wyzerowane (usunięte), a sprzęt wraca do ceny bazowej, o ile nie obowiązuje inna promocja.
+            </p>
+            <p class="text-gray-500 text-sm">
+                4.4. Administrator Serwisu ma wyłączne prawo do definiowania, modyfikowania bądź anulowania Promocji pojedynczych.
+            </p>
+        </div>
+
+        {{-- 5. Promocje na kategorie sprzętu --}}
+        <div class="mb-10 p-6 bg-white rounded-lg shadow">
+            <h2 class="text-2xl font-semibold mb-3">5. Promocje na kategorie sprzętu</h2>
+            <p class="mb-3 text-gray-700">
+                5.1. Promocja na kategorię obejmuje wszystkie sprzęty przypisane do tej samej kategorii (pole <code>category</code> w modelu <code>Equipment</code>).
+            </p>
+            <p class="mb-3 text-gray-700">
+                5.2. Parametry Promocji na kategorię to:
+            </p>
+            <ul class="list-disc list-inside mb-3 text-gray-700">
+                <li><strong>start_datetime</strong> – data i godzina rozpoczęcia promocji,</li>
+                <li><strong>end_datetime</strong> – data i godzina zakończenia promocji,</li>
+                <li><strong>discount</strong> – procent rabatu,</li>
+                <li><strong>promotion_type</strong> – wartość <code>'kategoria'</code> zostaje przypisana do wszystkich sprzętów w określonej kategorii.</li>
+            </ul>
+            <p class="mb-3 text-gray-700">
+                5.3. W okresie trwania Promocji na kategorię (tj. gdy bieżący czas mieści się w przedziale [<code>start_datetime</code>, <code>end_datetime</code>] włącznie), cena wyświetlana we wszystkich miejscach Serwisu (opis produktu, koszyk) dla sprzętów z danej kategorii obliczana jest według wzoru:
+            </p>
+            <pre class="bg-gray-100 p-4 rounded text-sm text-gray-800 mb-3">NewPrice = OriginalPrice × (1 – discount/100)</pre>
+            <p class="mb-3 text-gray-700">
+                5.4. Po zakończeniu <code>end_datetime</code> Promocja na kategorię automatycznie wygasa, a w polach <code>promotion_type</code>, <code>start_datetime</code>, <code>end_datetime</code> oraz <code>discount</code> zostają usunięte informacje na temat promocji. Sprzęty wracają do ceny bazowej, o ile nie obowiązuje dla nich Promocja pojedyncza.
+            </p>
+            <p class="text-gray-500 text-sm">
+                5.5. Administrator Serwisu jest jedynym podmiotem uprawnionym do ustanawiania, modyfikowania lub wygaszania Promocji na kategorie.
+            </p>
+        </div>
+
+        {{-- 6. Łączenie promocji --}}
+        <div class="mb-10 p-6 bg-white rounded-lg shadow">
+            <h2 class="text-2xl font-semibold mb-3">6. Łączenie promocji</h2>
+            <p class="mb-3 text-gray-700">
+                6.1. W przypadku, gdy na dany sprzęt mogłyby być aktywne jednocześnie różne typy promocji (pojedyncza, kategoria lub lojalnościowa), obowiązuje następująca kolejność priorytetów:
+            </p>
+            <ol class="list-decimal list-inside mb-3 text-gray-700">
+                <li><strong>Promocja pojedyncza</strong> (najwyższy priorytet).</li>
+                <li><strong>Promocja na kategorię</strong> (drugi priorytet).</li>
+                <li><strong>Promocja lojalnościowa</strong> (najniższy priorytet).</li>
+            </ol>
+            <p class="mb-3 text-gray-700">
+                6.2. Oznacza to, że:
+            </p>
+            <ul class="list-disc list-inside mb-3 text-gray-700">
+                <li>
+                    6.2.a. Jeżeli sprzęt posiada aktywną Promocję pojedynczą, stosuje się wyłącznie jej warunki (wysokość i okres Rabatu) – bez względu na inne promocje.
+                </li>
+                <li>
+                    6.2.b. Jeżeli sprzęt nie posiada aktywnej Promocji pojedynczej, lecz należy do kategorii objętej Promocją na kategorię, stosuje się warunki tej promocji.
+                </li>
+                <li>
+                    6.2.c. Jeżeli ani Promocja pojedyncza, ani Promocja na kategorię nie są aktywne, wówczas rozpatrywana jest możliwość przyznania Promocji lojalnościowej, o ile Użytkownik spełnia wymagania liczby zakończonych wypożyczeń (zob. § 3).
+                </li>
+                <li>
+                    6.2.d. Jeżeli żaden z powyższych mechanizmów nie uprawnia Użytkownika do uzyskania Rabatu, sprzęt sprzedawany jest w cenie bazowej (<code>OriginalPrice</code>).
+                </li>
+            </ul>
+            <p class="mb-3 text-gray-700">
+                6.3. Przykład zastosowania kolejności priorytetów:
+            </p>
+            <ul class="list-disc list-inside mb-3 text-gray-700">
+                <li>Produkt „Kamera XYZ” należy do kategorii „Kamery”.</li>
+                <li>Administrator wprowadził Promocję na kategorię „Kamery” w wysokości 10% z okresem od 1 czerwca do 7 czerwca.</li>
+                <li>Użytkownik ma zakończonych 4 wypożyczenia (rentals_count = 4), uprawniające do uzyskania 25% Rabatu lojalnościowego (na piąte wypożyczenie).</li>
+                <li>W dniu 3 czerwca:
+                    <ul class="list-disc list-inside ml-5 mb-2 text-gray-700">
+                        <li>Jeżeli „Kamera XYZ” ma aktywną Promocję pojedynczą (np. 30% Rabatu od 2 czerwca do 5 czerwca), wówczas stosuje się wyłącznie Rabat promocyjny 30%.</li>
+                        <li>Jeżeli „Kamera XYZ” nie ma Promocji pojedynczej, ale kategoria „Kamery” jest objęta 10% Rabatem, Użytkownik płaci cenę obniżoną o 10%.</li>
+                        <li>Jeżeli ani Promocja pojedyncza, ani Promocja na kategorię nie są aktywne, wówczas Użytkownik otrzymuje Promocję lojalnościową (25% Rabatu).</li>
+                    </ul>
+                </li>
+            </ul>
+        </div>
+
+        {{-- 7. Zasady obsługi promocji --}}
+        <div class="mb-10 p-6 bg-white rounded-lg shadow">
+            <h2 class="text-2xl font-semibold mb-3">7. Zasady obsługi promocji</h2>
+            <p class="mb-3 text-gray-700">
+                7.1. Rabat przyznawany jest automatycznie w procesie składania zamówienia lub wypożyczenia, po spełnieniu warunków określonych w niniejszym Regulaminie.
+            </p>
+            <p class="mb-3 text-gray-700">
+                7.2. W widoku koszyka, a także w szczegółach produktu, Użytkownik widzi:
+            </p>
+            <ul class="list-disc list-inside mb-3 text-gray-700">
+                <li>a) cenę bazową sprzętu (<code>OriginalPrice</code>),</li>
+                <li>b) wartość i rodzaj przyznanego Rabatu (np. „Rabat lojalnościowy 25%”),</li>
+                <li>c) cenę po Rabacie obliczoną zgodnie z kolejnością priorytetów.</li>
+            </ul>
+            <p class="mb-3 text-gray-700">
+                7.3. Po zakończeniu obowiązywania dowolnej promocji (po przekroczeniu <code>end_datetime</code>) pola związane z promocją w modelu <code>Equipment</code> (<code>promotion_type</code>, <code>start_datetime</code>, <code>end_datetime</code>, <code>discount</code>) są automatycznie wyzerowane (usuwane).
+            </p>
+            <p class="mb-3 text-gray-700">
+                7.4. Jeżeli Użytkownik wykupił usługę lub dokonał rezerwacji z zastosowaniem konkretnej promocji, a promocja wygaśnie przed finalizacją transakcji (np. utracenie połączenia, opóźnienie w płatności), zostanie zastosowana promocja o niższym priorytecie lub cena bazowa, jeżeli nie będzie innych aktywnych promocji.
+            </p>
+            <p class="mb-3 text-gray-700">
+                7.5. Każda zmiana statusu promocji (rozpoczęcie, zakończenie, modyfikacja) jest rejestrowana w systemie Serwisu. Użytkownik ma prawo do wglądu w historię swoich promocji w profilu użytkownika.
+            </p>
+        </div>
+
+        {{-- 8. Postanowienia końcowe --}}
+        <div class="p-6 bg-white rounded-lg shadow">
+            <h2 class="text-2xl font-semibold mb-3">8. Postanowienia końcowe</h2>
+            <p class="mb-3 text-gray-700">
+                8.1. Administrator dokłada najwyższych starań, aby informacje o promocjach były zawsze aktualne, jednak nie ponosi odpowiedzialności za opóźnienia w synchronizacji danych prezentowanych w Serwisie.
+            </p>
+            <p class="mb-3 text-gray-700">
+                8.2. W razie wystąpienia okoliczności nadzwyczajnych (awarie techniczne, błąd systemu itp.) Administrator zastrzega sobie prawo do czasowego zawieszenia promocji, bez prawa Użytkownika do odszkodowania.
+            </p>
+            <p class="mb-3 text-gray-700">
+                8.3. Wszelkie spory wynikłe z korzystania z promocji będą rozstrzygane polubownie, a w przypadku braku porozumienia – przez sąd właściwy miejscowo dla siedziby Administratora.
+            </p>
+            <p class="mb-3 text-gray-700">
+                8.4. W sprawach nieuregulowanych niniejszym Regulaminem zastosowanie mają przepisy powszechnie obowiązującego prawa Rzeczypospolitej Polskiej.
+            </p>
+            <p class="text-gray-500 text-sm">
+                8.5. Regulamin wchodzi w życie z dniem jego opublikowania na stronach Serwisu i obowiązuje do odwołania.
+            </p>
+        </div>
+    </section>
+@endsection

--- a/resources/views/rentals/summary.blade.php
+++ b/resources/views/rentals/summary.blade.php
@@ -1,3 +1,5 @@
+{{-- resources/views/rentals/summary.blade.php --}}
+
 @extends('layouts.app')
 
 @section('content')
@@ -6,7 +8,11 @@
 
         <div class="bg-white p-6 rounded shadow grid grid-cols-3 gap-6">
             <div class="col-span-1 flex items-start justify-center">
-                <img src="/{{ $equipment->thumbnail }}" alt="{{ $equipment->name }}" class="h-64 object-contain rounded">
+                <img
+                    src="/{{ $equipment->thumbnail }}"
+                    alt="{{ $equipment->name }}"
+                    class="h-64 object-contain rounded"
+                >
             </div>
 
             <div class="col-span-2">
@@ -16,9 +22,14 @@
                 <p><strong>Stan techniczny:</strong> {{ ucfirst($equipment->technical_state) }}</p>
                 <p class="mb-4"><strong>Opis:</strong> {{ $equipment->description }}</p>
 
-                <form action="{{ route('client.rentals.store') }}" method="POST" class="mt-4 max-w-60">
+                <form action="{{ route('client.rentals.store') }}" method="POST" class="mt-4 max-w-full">
                     @csrf
                     <input type="hidden" name="equipment_id" value="{{ $equipment->id }}">
+
+                    {{-- Ukryte pola, wypełniane przez JavaScript --}}
+                    <input type="hidden" name="discount_percent" id="discount_percent" value="0">
+                    <input type="hidden" name="discount_amount" id="discount_amount" value="0">
+                    <input type="hidden" name="discounted_total" id="discounted_total" value="0">
 
                     <label for="start_date" class="block font-medium mb-1">Data rozpoczęcia:</label>
                     <input
@@ -51,10 +62,13 @@
                         <label for="with_operator" class="font-medium">Potrzebuję operatora</label>
                     </div>
 
+                    {{-- Wyświetlenie kwoty przed i po rabacie --}}
                     <p id="total_price" class="font-semibold text-lg mb-4 hidden"></p>
 
-                    <button type="submit"
-                            class="bg-[#f56600] hover:bg-[#f98800] text-white font-semibold py-2 px-6 rounded w-full">
+                    <button
+                        type="submit"
+                        class="bg-[#f56600] hover:bg-[#f98800] text-white font-semibold py-2 px-6 rounded w-full"
+                    >
                         Podsumowanie i płatność
                     </button>
                 </form>
@@ -64,49 +78,109 @@
 
     <script>
         document.addEventListener('DOMContentLoaded', () => {
-            const startInput       = document.getElementById('start_date');
-            const endInput         = document.getElementById('end_date');
-            const withOperatorInput= document.getElementById('with_operator');
-            const totalPriceEl     = document.getElementById('total_price');
+            const startInput        = document.getElementById('start_date');
+            const endInput          = document.getElementById('end_date');
+            const withOperatorInput = document.getElementById('with_operator');
+            const totalPriceEl      = document.getElementById('total_price');
 
-            // cena sprzętu i stawka operatora pobrane z bazy
+            // 1. Ceny pobrane z backendu:
             const dailyPrice    = {{ $equipment->finalPrice() }};
             const operatorDaily = {{ $equipment->operator_daily_rate }};
 
-            function updateTotalPrice() {
-                const start = new Date(startInput.value);
-                const end   = new Date(endInput.value);
+            // 2. Liczba zakończonych wypożyczeń (przekazana z PHP):
+            const currentRentalsCount = {{ Auth::user()->rentals_count }};
 
-                if (start && end && end >= start) {
-                    const diffTime     = end - start;
-                    const diffDays     = Math.floor(diffTime / (1000 * 60 * 60 * 24)) + 1;
-                    const baseCost     = diffDays * dailyPrice;
-                    const operatorCost = withOperatorInput.checked
-                        ? diffDays * operatorDaily
-                        : 0;
-                    const total = (baseCost + operatorCost).toFixed(2);
-
-                    const breakdown = [
-                        `${diffDays} dni × ${dailyPrice.toFixed(2).replace('.', ',')} zł = ${baseCost.toFixed(2).replace('.', ',')} zł`,
-                    ];
-
-                    if (withOperatorInput.checked) {
-                        breakdown.push(
-                            `${diffDays} dni × ${operatorDaily.toFixed(2).replace('.', ',')} zł = ${operatorCost.toFixed(2).replace('.', ',')} zł`
-                        );
-                    }
-
-                    totalPriceEl.innerHTML = `
-            Cena całkowita: <strong>${total.replace('.', ',')} zł</strong><br>
-            <small>${breakdown.join('<br>')}</small>
-          `;
-                    totalPriceEl.classList.remove('hidden');
-                } else {
-                    totalPriceEl.textContent = '';
-                    totalPriceEl.classList.add('hidden');
-                }
+            // 3. Logika zniżek lojalnościowych:
+            function getDiscountPercent(rentalsCount) {
+                if (rentalsCount === 0) return 20;
+                if (((rentalsCount + 1) % 20) === 0) return 50;
+                if (((rentalsCount + 1) % 5) === 0) return 25;
+                return 0;
             }
 
+            function updateTotalPrice() {
+                const startVal = startInput.value;
+                const endVal   = endInput.value;
+
+                if (!startVal || !endVal) {
+                    totalPriceEl.textContent = '';
+                    totalPriceEl.classList.add('hidden');
+                    return;
+                }
+
+                const start = new Date(startVal);
+                const end   = new Date(endVal);
+
+                if (end < start) {
+                    totalPriceEl.textContent = '';
+                    totalPriceEl.classList.add('hidden');
+                    return;
+                }
+
+                // 4. Obliczamy liczbę dni:
+                const diffTime = end - start;
+                const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24)) + 1;
+
+                // 5. Koszty bazowe:
+                const baseCost     = parseFloat((diffDays * dailyPrice).toFixed(2));
+                const operatorCost = withOperatorInput.checked
+                    ? parseFloat((diffDays * operatorDaily).toFixed(2))
+                    : 0;
+                const rawTotal     = parseFloat((baseCost + operatorCost).toFixed(2));
+
+                // 6. Rabat lojalnościowy:
+                const discountPercent = getDiscountPercent(currentRentalsCount);
+                const discountAmount  = parseFloat((rawTotal * (discountPercent / 100)).toFixed(2));
+                const discountedTotal = parseFloat((rawTotal - discountAmount).toFixed(2));
+
+                // 7. Przygotowujemy breakdown:
+                const breakdownLines = [
+                    `${diffDays} dni × ${dailyPrice.toFixed(2).replace('.', ',')} zł = ${baseCost.toFixed(2).replace('.', ',')} zł`
+                ];
+                if (withOperatorInput.checked) {
+                    breakdownLines.push(
+                        `${diffDays} dni × ${operatorDaily.toFixed(2).replace('.', ',')} zł = ${operatorCost.toFixed(2).replace('.', ',')} zł`
+                    );
+                }
+
+                // 8. Składamy HTML:
+                let html = `
+                    Cena przed rabatem: <strong>${rawTotal.toFixed(2).replace('.', ',')} zł</strong><br>
+                    <small>${breakdownLines.join('<br>')}</small>
+                `;
+
+                if (discountPercent > 0) {
+                    html += `
+                        <div class="mt-2 p-3 bg-green-50 border border-green-200 rounded">
+                            <p>
+                                <strong>Zniżka lojalnościowa:</strong>
+                                To będzie Twoje <strong>${currentRentalsCount + 1}.</strong> wypożyczenie,
+                                otrzymujesz <strong>–${discountPercent}%</strong>.
+                            </p>
+                            <p><strong>Kwota rabatu:</strong> –${discountAmount.toFixed(2).replace('.', ',')} zł</p>
+                            <p><strong>Do zapłaty po rabacie:</strong>
+                                <span class="text-red-600 font-bold">${discountedTotal.toFixed(2).replace('.', ',')} zł</span>
+                            </p>
+                        </div>
+                    `;
+                } else {
+                    html += `
+                        <p class="mt-2 text-sm text-gray-600">
+                            Brak zniżki lojalnościowej dla tego wypożyczenia.
+                        </p>
+                    `;
+                }
+
+                totalPriceEl.innerHTML = html;
+                totalPriceEl.classList.remove('hidden');
+
+                // 9. Ustawiamy wartości w ukrytych polach:
+                document.getElementById('discount_percent').value = discountPercent;
+                document.getElementById('discount_amount').value  = discountAmount.toFixed(2);
+                document.getElementById('discounted_total').value = discountedTotal.toFixed(2);
+            }
+
+            // 10. Nasłuchujemy na zmiany pól:
             startInput.addEventListener('change', () => {
                 if (startInput.value) {
                     endInput.min = startInput.value;

--- a/routes/web.php
+++ b/routes/web.php
@@ -129,4 +129,8 @@ Route::middleware(['auth'])->prefix('admin/rentals')->name('admin.rentals.')->gr
     Route::post('complaints/{rental}/resolve', [AdminRentalComplaintController::class, 'resolve'])->name('complaints.resolve');
 });
 
+Route::get('/promocje/regulamin', function () {
+    return view('promotions.rules');
+})->name('promotions.rules');
+
 require __DIR__.'/auth.php';


### PR DESCRIPTION
- Added a section for displaying promotion terms and conditions on the relevant page.
- Integrated the terms and conditions for promotions to ensure users are informed about the rules before participating.
- Updated frontend to show the promotion details clearly to users.

/equipments/{show}:
![image](https://github.com/user-attachments/assets/b9b52ca9-d3dc-4702-855f-f6435185887f)

/client/rentals/summary/3
![image](https://github.com/user-attachments/assets/dc422ab2-28c7-47a3-8c0c-379a0d6c67dc)

/client/rentals/payment
![image](https://github.com/user-attachments/assets/70ed2a9a-8e8b-4c67-b54c-5133db9477b4)

![image](https://github.com/user-attachments/assets/3b16df32-dc78-427f-8fc1-c964c3c5cf17)
